### PR TITLE
remove early check for empty filter

### DIFF
--- a/public/market.js
+++ b/public/market.js
@@ -80,7 +80,6 @@
 
       get filteredRows() {
         let q = this.filter.toLowerCase();
-        if (!q) return this.rows;
         let tokens = q.split(/\s+/);
         return this.rows.filter((row) => {
           let matchStatus = (


### PR DESCRIPTION
With the tokens getting split up the way they are, and the protection
against empty string tokens, we no longer need to bail if the filter is
empty. This also enables the status buttons to filter the list when
there's no search query.